### PR TITLE
Create `constructors.py` for helper functions

### DIFF
--- a/turbopy/__init__.py
+++ b/turbopy/__init__.py
@@ -1,3 +1,4 @@
 from .core import *
 from .diagnostics import *
 from .computetools import *
+from .constructors import *

--- a/turbopy/constructors.py
+++ b/turbopy/constructors.py
@@ -1,0 +1,24 @@
+"""Helper functions for constructing Simulations"""
+import qtoml as toml
+
+from .core import Simulation
+
+def construct_simulation_from_toml(filename: str) -> Simulation:
+    """Construct a Simulation instance from a toml input file
+
+    Parameters
+    ----------
+    filename : `str`
+        The name of the file which contains the input specification, in
+        `toml` format.
+
+    Returns
+    -------
+    simulation_instance : `Simulation`
+        An instance of the Simulation class, initialized using the data
+        in the input file, which was converted into a python dictionary.
+    """
+    with open(filename) as f:
+        input_data = toml.load(f)
+
+    return Simulation(input_data)

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -3,32 +3,9 @@ Computational Physics Simulation Framework
 
 Based on the structure of turboWAVE
 """
-
 from pathlib import Path
 from abc import ABC, abstractmethod
 import numpy as np
-import qtoml as toml
-
-
-def construct_simulation_from_toml(filename: str) -> Simulation:
-    """Construct a Simulation instance from a toml input file
-
-    Parameters
-    ----------
-    filename : `str`
-        The name of the file which contains the input specification, in
-        `toml` format.
-
-    Returns
-    -------
-    simulation_instance : `Simulation`
-        An instance of the Simulation class, initialized using the data
-        in the input file, which was converted into a python dictionary.
-    """
-    with open(input_data) as f:
-        input_data = toml.load(f)
-
-    return Simulation(input_data)
 
 
 class Simulation:

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -10,6 +10,27 @@ import numpy as np
 import qtoml as toml
 
 
+def construct_simulation_from_toml(filename: str) -> Simulation:
+    """Construct a Simulation instance from a toml input file
+
+    Parameters
+    ----------
+    filename : `str`
+        The name of the file which contains the input specification, in
+        `toml` format.
+
+    Returns
+    -------
+    simulation_instance : `Simulation`
+        An instance of the Simulation class, initialized using the data
+        in the input file, which was converted into a python dictionary.
+    """
+    with open(input_data) as f:
+        input_data = toml.load(f)
+
+    return Simulation(input_data)
+
+
 class Simulation:
     """
     This Class "owns" all the physics modules, compute tools, and diagnostics.
@@ -20,11 +41,6 @@ class Simulation:
     """
 
     def __init__(self, input_data: dict):
-        # Check if the input is a filename of parameters to parse
-        if isinstance(input_data, str):
-            with open(input_data) as f:
-                input_data = toml.load(f)
-
         self.physics_modules = []
         self.compute_tools = []
         self.diagnostics = []


### PR DESCRIPTION
I'm refactoring to move the `qtoml` parsing logic into a separate function (in a separate file). This address #22. It cleans up the constructor for the `Simulation` class, and also starts laying groundwork for other possible "helper" style Simulation constructors.