### PR TITLE
Fix divide-by-zero warning

### DIFF
--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -599,8 +599,7 @@ class Grid:
         self.cell_widths = (self.r[1:] - self.r[:-1])
         with np.errstate(divide='ignore'):
             self.r_inv = 1 / self.r
-            if self.r[0] == 0:
-                self.r_inv[0] = 0
+            self.r_inv[self.r_inv==np.inf] = 0
 
     def parse_grid_data(self):
         """

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -597,10 +597,10 @@ class Grid:
         self.cell_edges = self.r
         self.cell_centers = (self.r[1:] + self.r[:-1]) / 2
         self.cell_widths = (self.r[1:] - self.r[:-1])
-        # This will give a divide-by-zero warning.
-        # I'm ok with that for now.
-        self.r_inv = 1 / self.r
-        self.r_inv[0] = 0
+        with np.errstate(divide='ignore'):
+            self.r_inv = 1 / self.r
+            if self.r[0] == 0:
+                self.r_inv[0] = 0
 
     def parse_grid_data(self):
         """


### PR DESCRIPTION
# Pull Request
### Description

The grid class computes 1/r. But if r=0 is in the grid, then numpy raises a divide-by-zero warning.

This PR fixes that by (locally) ignoring the warning, then gets rid of the `inf` by setting it to zero.