### PR TITLE
Add custom_name to compute_tools in core.py

### DIFF
--- a/tests/fixtures/block_on_spring/block_on_spring.py
+++ b/tests/fixtures/block_on_spring/block_on_spring.py
@@ -149,9 +149,9 @@ def bos_run():
             }
         },
         "Tools": {
-            "Leapfrog": [{}],
-            "BlockForwardEuler": [{}],
-            "BackwardEuler":[{}]
+            "Leapfrog": {},
+            "BlockForwardEuler": {},
+            "BackwardEuler":{}
         },
         "Diagnostics": {
             # default values come first

--- a/tests/fixtures/block_on_spring/block_on_spring.py
+++ b/tests/fixtures/block_on_spring/block_on_spring.py
@@ -149,9 +149,9 @@ def bos_run():
             }
         },
         "Tools": {
-            "Leapfrog": {},
-            "BlockForwardEuler": {},
-            "BackwardEuler": {}
+            ("Leapfrog",): {},
+            ("BlockForwardEuler",): {},
+            ("BackwardEuler",): {}
         },
         "Diagnostics": {
             # default values come first

--- a/tests/fixtures/block_on_spring/block_on_spring.py
+++ b/tests/fixtures/block_on_spring/block_on_spring.py
@@ -149,9 +149,9 @@ def bos_run():
             }
         },
         "Tools": {
-            ("Leapfrog",): {},
-            ("BlockForwardEuler",): {},
-            ("BackwardEuler",): {}
+            "Leapfrog": [{}],
+            "BlockForwardEuler": [{}],
+            "BackwardEuler":[{}]
         },
         "Diagnostics": {
             # default values come first

--- a/tests/fixtures/particle_in_field/particle_in_field.py
+++ b/tests/fixtures/particle_in_field/particle_in_field.py
@@ -141,5 +141,4 @@ def pif_run():
     ComputeTool.register("ForwardEuler", ForwardEuler)
     input_file = "tests/fixtures/particle_in_field/particle_in_field.toml"
     sim = construct_simulation_from_toml(input_file)
-    sim.input_data["Tools"][("ForwardEuler",)] = sim.input_data["Tools"].pop("ForwardEuler")
     sim.run()

--- a/tests/fixtures/particle_in_field/particle_in_field.py
+++ b/tests/fixtures/particle_in_field/particle_in_field.py
@@ -141,4 +141,5 @@ def pif_run():
     ComputeTool.register("ForwardEuler", ForwardEuler)
     input_file = "tests/fixtures/particle_in_field/particle_in_field.toml"
     sim = construct_simulation_from_toml(input_file)
+    sim.input_data["Tools"][("ForwardEuler",)] = sim.input_data["Tools"].pop("ForwardEuler")
     sim.run()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,7 +22,8 @@ def sim_fixt():
            "Clock": {"start_time": 0,
                      "end_time": 10,
                      "num_steps": 100},
-           "Tools": {"ExampleTool": {"type": "ExampleTool", "custom_name": "example"}},
+           "Tools": {("ExampleTool", "example"): {"type": "ExampleTool", "custom_name": "example"},
+                     ("ExampleTool", "example2"): {"type": "ExampleTool", "custom_name": "example2"}},
            "PhysicsModules": {"ExampleModule": {}},
            }
     return Simulation(dic)
@@ -40,7 +41,8 @@ def test_simulation_init_should_create_class_instance_when_called(simple_sim):
            "Clock": {"start_time": 0,
                      "end_time": 10,
                      "num_steps": 100},
-           "Tools": {"ExampleTool": {"type": "ExampleTool", "custom_name": "example"}},
+           "Tools": {("ExampleTool", "example"): {"type": "ExampleTool", "custom_name": "example"},
+                     ("ExampleTool", "example2"): {"type": "ExampleTool", "custom_name": "example2"}},
            "PhysicsModules": {"ExampleModule":{}}
            }
     assert simple_sim.input_data == dic
@@ -83,6 +85,8 @@ def test_read_tools_from_input_should_set_tools_attr_when_called(simple_sim):
     simple_sim.read_tools_from_input()
     assert simple_sim.compute_tools[0].owner == simple_sim
     assert simple_sim.compute_tools[0].input_data == {"type": "ExampleTool", "custom_name": "example"}
+    assert simple_sim.compute_tools[1].owner == simple_sim
+    assert simple_sim.compute_tools[1].input_data == {"type": "ExampleTool", "custom_name": "example2"}
 
 
 def test_fundamental_cycle_should_advance_clock_when_called(simple_sim):
@@ -110,8 +114,12 @@ def test_read_modules_from_input_should_set_modules_attr_when_called(simple_sim)
 def test_find_tool_by_name_should_identify_one_tool(simple_sim):
     simple_sim.read_tools_from_input()
     tool = simple_sim.find_tool_by_name("ExampleTool", "example")
+    tool2 = simple_sim.find_tool_by_name("ExampleTool", "example2")
+
     assert tool.input_data["type"] == "ExampleTool"
     assert tool.input_data["custom_name"] == "example"
+    assert tool2.input_data["type"] == "ExampleTool"
+    assert tool2.input_data["custom_name"] == "example2"
 
 
 #Grid class test methods

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -64,7 +64,7 @@ def test_simulation_init_should_create_class_instance_when_called(simple_sim):
                         {"custom_name": "example2"}]},
            "PhysicsModules": {"ExampleModule": {}},
            "Diagnostics": {
-               #default values come first
+               # default values come first
                "clock": {},
                "ExampleDiagnostic": [
                    {},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,7 +62,7 @@ def test_simulation_init_should_create_class_instance_when_called(simple_sim):
            "Tools": {"ExampleTool": [
                         {"custom_name": "example"},
                         {"custom_name": "example2"}]},
-           "PhysicsModules": {"ExampleModule":{}}
+           "PhysicsModules": {"ExampleModule": {}},
            "Diagnostics": {
                #default values come first
                "clock": {},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,7 +22,7 @@ def sim_fixt():
            "Clock": {"start_time": 0,
                      "end_time": 10,
                      "num_steps": 100},
-           "Tools": {"ExampleTool": {}},
+           "Tools": {"ExampleTool": {"type": "ExampleTool", "custom_name": "example"}},
            "PhysicsModules": {"ExampleModule": {}},
            }
     return Simulation(dic)
@@ -40,8 +40,8 @@ def test_simulation_init_should_create_class_instance_when_called(simple_sim):
            "Clock": {"start_time": 0,
                      "end_time": 10,
                      "num_steps": 100},
-           "Tools": {"ExampleTool": {}},
-           "PhysicsModules": {"ExampleModule": {}}
+           "Tools": {"ExampleTool": {"type": "ExampleTool", "custom_name": "example"}},
+           "PhysicsModules": {"ExampleModule":{}}
            }
     assert simple_sim.input_data == dic
 
@@ -82,7 +82,7 @@ def test_read_tools_from_input_should_set_tools_attr_when_called(simple_sim):
     ComputeTool.register("ExampleTool", ExampleTool)
     simple_sim.read_tools_from_input()
     assert simple_sim.compute_tools[0].owner == simple_sim
-    assert simple_sim.compute_tools[0].input_data == {"type": "ExampleTool"}
+    assert simple_sim.compute_tools[0].input_data == {"type": "ExampleTool", "custom_name": "example"}
 
 
 def test_fundamental_cycle_should_advance_clock_when_called(simple_sim):
@@ -106,6 +106,12 @@ def test_read_modules_from_input_should_set_modules_attr_when_called(simple_sim)
     simple_sim.read_modules_from_input()
     assert simple_sim.physics_modules[0].owner == simple_sim
     assert simple_sim.physics_modules[0].input_data == {"name": "ExampleModule"}
+
+def test_find_tool_by_name_should_identify_one_tool(simple_sim):
+    simple_sim.read_tools_from_input()
+    tool = simple_sim.find_tool_by_name("ExampleTool", "example")
+    assert tool.input_data["type"] == "ExampleTool"
+    assert tool.input_data["custom_name"] == "example"
 
 
 #Grid class test methods

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,8 +22,9 @@ def sim_fixt():
            "Clock": {"start_time": 0,
                      "end_time": 10,
                      "num_steps": 100},
-           "Tools": {("ExampleTool", "example"): {"type": "ExampleTool", "custom_name": "example"},
-                     ("ExampleTool", "example2"): {"type": "ExampleTool", "custom_name": "example2"}},
+           "Tools": {"ExampleTool": [
+                    {"custom_name": "example"},
+                    {"custom_name": "example2"}]},
            "PhysicsModules": {"ExampleModule": {}},
            }
     return Simulation(dic)
@@ -41,8 +42,9 @@ def test_simulation_init_should_create_class_instance_when_called(simple_sim):
            "Clock": {"start_time": 0,
                      "end_time": 10,
                      "num_steps": 100},
-           "Tools": {("ExampleTool", "example"): {"type": "ExampleTool", "custom_name": "example"},
-                     ("ExampleTool", "example2"): {"type": "ExampleTool", "custom_name": "example2"}},
+           "Tools": {"ExampleTool": [
+                    {"custom_name": "example"},
+                    {"custom_name": "example2"}]},
            "PhysicsModules": {"ExampleModule":{}}
            }
     assert simple_sim.input_data == dic

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -212,13 +212,15 @@ class Simulation:
     def read_tools_from_input(self):
         """Construct :class:`ComputeTools` based on input"""
         if "Tools" in self.input_data:
-            for tool_names, params in self.input_data["Tools"].items():
-                tool_class = ComputeTool.lookup(tool_names[0])
-                params["type"] = tool_names[0]
-                if "custom_name" in params:
-                    params["custom_name"] = tool_names[1]
-                self.compute_tools.append(tool_class(
-                    owner=self, input_data=params))
+            for tool_name, params in self.input_data["Tools"].items():
+                tool_class = ComputeTool.lookup(tool_name)
+                if len(params) >= 1:
+                    for tool in params:
+                        tool["type"] = tool_name
+                        self.compute_tools.append(tool_class(owner=self, input_data=tool))
+                else:
+                    params["type"] = tool_name
+                    self.compute_tools.append(tool_class(owner=self, input_data=params))
 
     def read_modules_from_input(self):
         """Construct :class:`PhysicsModule` instances based on input"""

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -212,11 +212,11 @@ class Simulation:
     def read_tools_from_input(self):
         """Construct :class:`ComputeTools` based on input"""
         if "Tools" in self.input_data:
-            for tool_name, params in self.input_data["Tools"].items():
-                tool_class = ComputeTool.lookup(tool_name)
-                params["type"] = tool_name
-                # TODO: somehow make tool names unique, or prevent
-                #  more than one each
+            for tool_names, params in self.input_data["Tools"].items():
+                tool_class = ComputeTool.lookup(tool_names[0])
+                params["type"] = tool_names[0]
+                if "custom_name" in params:
+                    params["custom_name"] = tool_names[1]
                 self.compute_tools.append(tool_class(
                     owner=self, input_data=params))
 

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -270,12 +270,12 @@ class Simulation:
         Unused stub for future implementation"""
         pass
 
-    def find_tool_by_name(self, tool_name: str, custom_name=None: str):
+    def find_tool_by_name(self, tool_name: str, custom_name: str = None):
         """Returns the :class:`ComputeTool` associated with the
         given name"""
         tools = [t for t in self.compute_tools if t.name == tool_name]
         for t in tools:
-            if not (t.custom_name == custom_name):
+            if not t.custom_name == custom_name:
                 tools.remove(t)
         if len(tools) == 1:
             return tools[0]

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -270,10 +270,13 @@ class Simulation:
         Unused stub for future implementation"""
         pass
 
-    def find_tool_by_name(self, tool_name: str):
+    def find_tool_by_name(self, tool_name: str, custom_name=None: str):
         """Returns the :class:`ComputeTool` associated with the
         given name"""
         tools = [t for t in self.compute_tools if t.name == tool_name]
+        for t in tools:
+            if not (t.custom_name == custom_name):
+                tools.remove(t)
         if len(tools) == 1:
             return tools[0]
         return None
@@ -454,6 +457,9 @@ class ComputeTool(DynamicFactory):
         object such as its name.
     name : str
         Type of ComputeTool.
+    custom_name: str
+        Name given to individual instance of tool, optional.
+        Used when multiple tools of the same type exist in one :class:`Simulation`
     """
 
     _factory_type_name = "Compute Tool"
@@ -463,6 +469,9 @@ class ComputeTool(DynamicFactory):
         self.owner = owner
         self.input_data = input_data
         self.name = input_data["type"]
+        self.custom_name = None
+        if "instance" in input_data:
+            self.custom_name = input_data["instance"]
 
     def initialize(self):
         """Perform any initialization operations needed for this tool"""

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -214,10 +214,14 @@ class Simulation:
         if "Tools" in self.input_data:
             for tool_name, params in self.input_data["Tools"].items():
                 tool_class = ComputeTool.lookup(tool_name)
-                if len(params) >= 1:
-                    for tool in params:
-                        tool["type"] = tool_name
-                        self.compute_tools.append(tool_class(owner=self, input_data=tool))
+                if isinstance(params, list):
+                    if len(params) >= 1:
+                        for tool in params:
+                            tool["type"] = tool_name
+                            self.compute_tools.append(tool_class(owner=self, input_data=tool))
+                    else:
+                        params[0] = {"type": tool_name}
+                        self.compute_tools.append(tool_class(owner=self, input_data=params[0]))
                 else:
                     params["type"] = tool_name
                     self.compute_tools.append(tool_class(owner=self, input_data=params))

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -214,18 +214,12 @@ class Simulation:
         if "Tools" in self.input_data:
             for tool_name, params in self.input_data["Tools"].items():
                 tool_class = ComputeTool.lookup(tool_name)
-                if isinstance(params, list):
-                    if len(params) >= 1:
-                        for tool in params:
-                            tool["type"] = tool_name
-                            self.compute_tools.append(tool_class(owner=self, input_data=tool))
-                    else:
-                        params[0] = {"type": tool_name}
-                        self.compute_tools.append(tool_class(owner=self, input_data=params[0]))
-                else:
-                    params["type"] = tool_name
-                    self.compute_tools.append(tool_class(owner=self, input_data=params))
-
+                if not isinstance(params, list):
+                    params = [params]
+                for tool in params:
+                     tool["type"] = tool_name
+                     self.compute_tools.append(tool_class(owner=self, input_data=tool)) 
+    
     def read_modules_from_input(self):
         """Construct :class:`PhysicsModule` instances based on input"""
         for physics_module_name, physics_module_data in \

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -273,10 +273,7 @@ class Simulation:
     def find_tool_by_name(self, tool_name: str, custom_name: str = None):
         """Returns the :class:`ComputeTool` associated with the
         given name"""
-        tools = [t for t in self.compute_tools if t.name == tool_name]
-        for t in tools:
-            if not t.custom_name == custom_name:
-                tools.remove(t)
+        tools = [t for t in self.compute_tools if t.name == tool_name and t.custom_name == custom_name]
         if len(tools) == 1:
             return tools[0]
         return None
@@ -470,8 +467,8 @@ class ComputeTool(DynamicFactory):
         self.input_data = input_data
         self.name = input_data["type"]
         self.custom_name = None
-        if "instance" in input_data:
-            self.custom_name = input_data["instance"]
+        if "custom_name" in input_data:
+            self.custom_name = input_data["custom_name"]
 
     def initialize(self):
         """Perform any initialization operations needed for this tool"""


### PR DESCRIPTION
# Pull Request
### Description
Add a custom_name parameter to the ComputeTool class. Edit Simulation's find_tool_by_name to search for custom_name as well as name. Multiple ComputeTools of the same type should now be allowed
This pull request addresses #116 

- [x] make sure you are pulling from a dev branch on your fork
- [x] check for code linting
