### PR TITLE
Fix typo in core.py

### DIFF
--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -78,7 +78,7 @@ class Simulation:
 
         ``"Diagnostics"`` : `dict` [`str`, `dict`], optional
             Dictionary of :class:`Diagnostic` items needed for the
-            simulaiton.
+            simulation.
 
             Each key in the dictionary should map to a
             :class:`Diagnostic` subclass key in the :class:`Diagnostic`


### PR DESCRIPTION
# Pull Request
## Description
Fixes the typo in line 81 of core.py

This pull request addresses #129 

## Checklist
The following items have been checked for this PR:

- [x] Conforms to PEP8 style standards (check with `pylint`, `flake8`, or similar)
- [x] Code is documented with docstrings, or docstrings have been updated as appropriate
- [x] New unit test/integration test have been added to check new code
- [x] All existing tests still pass
