### PR TITLE
Change sequence of steps in `prepare_simulation`

### DIFF
--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -171,6 +171,9 @@ class Simulation:
         """
         print("Reading Grid...")
         self.read_grid_from_input()
+        
+        print("Initializing Simulation Clock...")
+        self.read_clock_from_input()
 
         print("Reading Tools...")
         self.read_tools_from_input()
@@ -180,9 +183,6 @@ class Simulation:
 
         print("Reading Diagnostics...")
         self.read_diagnostics_from_input()
-
-        print("Initializing Simulation Clock...")
-        self.read_clock_from_input()
 
         print("Initializing Tools...")
         for t in self.compute_tools:


### PR DESCRIPTION
# Pull Request
## Description
This PR changes the order of the steps in `prepare_simulation`. Now the clock will be created before the physics modules.

This pull request addresses #140 

## Checklist
The following items have been checked for this PR:

- [x] Conforms to PEP8 style standards (check with `pylint`, `flake8`, or similar)
- [ ] Code is documented with docstrings, or docstrings have been updated as appropriate
- [ ] New unit test/integration test have been added to check new code
- [x] All existing tests still pass
