### PR TITLE
Add functionality that lets the clock turn back time

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,11 +136,23 @@ def test_run_should_run_simulation_while_clock_is_running(simple_sim):
     assert simple_sim.clock.time == 10
 
 
+def test_turn_back_should_turn_back_time_when_called(simple_sim):
+    """Test fundamental_cycle method in Simulation class"""
+    simple_sim.read_clock_from_input()
+    simple_sim.fundamental_cycle()
+    assert simple_sim.clock.this_step == 1
+    assert simple_sim.clock.time == 0.1
+    simple_sim.clock.turn_back()
+    assert simple_sim.clock.this_step == 0
+    assert simple_sim.clock.time == 0
+
+
 def test_read_modules_from_input_should_set_modules_attr_when_called(simple_sim):
     """Test read_modules_from_input method in Simulation calss"""
     simple_sim.read_modules_from_input()
     assert simple_sim.physics_modules[0]._owner == simple_sim
     assert simple_sim.physics_modules[0]._input_data == {"name": "ExampleModule"}
+
 
 def test_find_tool_by_name_should_identify_one_tool(simple_sim):
     simple_sim.read_tools_from_input()

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -593,6 +593,13 @@ class SimulationClock:
         self.time = self.start_time + self.dt * self.this_step
         if self.print_time:
             print(f"t = {self.time}")
+    
+    def turn_back(self, num_steps=1):
+        """Set the time back `num_steps` time steps"""
+        self.this_step = self.this_step - num_steps
+        self.time = self.start_time + self.dt * self.this_step
+        if self.print_time:
+            print(f"t = {self.time}")        
 
     def is_running(self):
         """Check if time is less than end time"""


### PR DESCRIPTION
# Pull Request
## Description
This introduces a new function `turn_back` that lets the clock turn back simulation time.

This pull request addresses #143 

## Checklist
The following items have been checked for this PR:

- [x] Conforms to PEP8 style standards (check with `pylint`, `flake8`, or similar)
- [x] Code is documented with docstrings, or docstrings have been updated as appropriate
- [x] New unit test/integration test have been added to check new code
- [x] All existing tests still pass
