### PR TITLE
Fix Default Sharing Name

### DIFF
--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -434,7 +434,7 @@ class PhysicsModule(DynamicFactory):
         not start with an underscore) will be shared with the key
         `<class_name>_<attribute_name>`.
         """
-        shared = {f'{self.__class__}_{attribute}': value for attribute, value
+        shared = {f'{self.__class__.__name__}_{attribute}': value for attribute, value
                   in self.__dict__.items()
                   if not attribute.startswith('_')}
         self.publish_resource(shared)


### PR DESCRIPTION
# Pull Request
## Description
Fixes default sharing name in PhysicsModule from `<class 'ExampleModule'>` to `ExampleModule`

This pull request addresses #147 

## Checklist
The following items have been checked for this PR:

- [ ] Conforms to PEP8 style standards (check with `pylint`, `flake8`, or similar)
- [ ] Code is documented with docstrings, or docstrings have been updated as appropriate
- [ ] New unit test/integration test have been added to check new code
- [ ] All existing tests still pass
