### PR TITLE
Total walltime of simulation

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -315,6 +315,23 @@ def test_turn_back_should_turn_back_time_when_called(simple_sim):
     assert simple_sim.clock.this_step == 0
     assert simple_sim.clock.time == 0
 
+def test_wall_time_attrs_default_to_none(simple_sim):
+    """Wall-time attributes should be None before run() is called."""
+    assert simple_sim.wall_start_time is None
+    assert simple_sim.wall_end_time is None
+    assert simple_sim.wall_time is None
+
+
+def test_run_records_wall_time(simple_sim):
+    """After run(), wall_time should be populated and non-negative."""
+    simple_sim.run()
+    assert simple_sim.wall_start_time is not None
+    assert simple_sim.wall_end_time is not None
+    assert simple_sim.wall_time is not None
+    assert simple_sim.wall_time >= 0
+    assert simple_sim.wall_time == pytest.approx(
+        simple_sim.wall_end_time - simple_sim.wall_start_time)
+
 
 def test_read_modules_from_input_should_set_modules_attr_when_called(simple_sim):
     """Test read_modules_from_input method in Simulation class"""

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 import numpy as np
 import warnings
+import time
 
 
 class Simulation:
@@ -121,6 +122,16 @@ class Simulation:
         A list of :class:`Diagnostic` objects for this simulation.
     compute_tools : list of :class:`ComputeTool` subclass objects
         A list of :class:`ComputeTool` objects for this simulation.
+    wall_start_time : `float` or None
+        Wall-clock (`time.time()`) timestamp captured at the start of
+        :meth:`run`. ``None`` until the simulation runs.
+    wall_end_time : `float` or None
+        Wall-clock timestamp captured at the end of :meth:`run`.
+        ``None`` until the simulation completes.
+    wall_time : `float` or None
+        Total wall-clock duration of :meth:`run` in seconds
+        (``wall_end_time - wall_start_time``). ``None`` until
+        :meth:`run` completes.
     """
 
     def __init__(self, input_data: dict):
@@ -131,6 +142,10 @@ class Simulation:
         self.grid = None
         self.clock = None
         self.units = None
+
+        self.wall_start_time = None
+        self.wall_end_time = None
+        self.wall_time = None
 
         self.input_data = input_data
 
@@ -145,8 +160,10 @@ class Simulation:
         Runs the simulation
 
         This initializes the simulation, runs the main loop, and then
-        finalizes the simulation.
+        finalizes the simulation. Wall-clock time for the full
+        :meth:`run` is recorded in :attr:`wall_time`.
         """
+        self.wall_start_time = time.time()
         print("Simulation is initializing")
         self.prepare_simulation()
         print("Initialization complete")
@@ -156,6 +173,9 @@ class Simulation:
             self.fundamental_cycle()
 
         self.finalize_simulation()
+        self.wall_end_time = time.time()
+        self.wall_time = self.wall_end_time - self.wall_start_time
+        print(f"Simulation duration = {self.wall_time} seconds")
         print("Simulation complete")
 
     def fundamental_cycle(self):


### PR DESCRIPTION
##Fixed #168 
## Summary
Adds wall-clock timing to `Simulation.run()` so users can see how long a
simulation actually took to execute. Useful for optimization work where
the physics domain time (`SimulationClock`) tells you nothing about
computational cost.

- New attributes on `Simulation`: `wall_start_time`, `wall_end_time`,
  `wall_time` (all `float` seconds, `None` until `run()` completes).
- `Simulation.run()` records `time.time()` at entry and exit, then
  prints `Simulation duration = <wall_time> seconds` before the final
  "Simulation complete" line.

## Design note: why `Simulation` and not `SimulationClock`
`SimulationClock` models *physics* time — its `start_time`, `end_time`,
`dt`, and `time` attributes all refer to the simulated physical domain.
Wall time is a *computational* concept and lives at the lifecycle level
that `Simulation.run()` owns, so overloading `SimulationClock` with a
second, unrelated meaning of "time" was avoided.

## Test plan
- [x] `pytest tests/test_core.py` — new tests pass:
  - `test_wall_time_attrs_default_to_none` (verifies `None` before `run()`)
  - `test_run_records_wall_time` (verifies attrs populated, non-negative,
    and `wall_time == wall_end_time - wall_start_time` after `run()`)
- [x] `pytest` full suite: 67 passed
Final state:

Local & remote (ndisner/total-time-of-simulation) both at d2ba6a8 — one clean commit ahead of main
Previous 31b6562 and 14242e1 are gone from the branch (force-with-lease succeeded, base was as expected)
