### PR TITLE
Possible solution

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ TurboPy: a framework for computational physics
    :caption: Contents
 
    getting_started
+   sharing_data
    api
 
 

--- a/docs/sharing_data.rst
+++ b/docs/sharing_data.rst
@@ -1,0 +1,32 @@
+Sharing Resources
+=================
+
+It is often necessary to share resources between custom :class:`turbopy.core.PhyiscsModules` or :class:`turbopy.core.Diagnostics`. A new API has been developed to assist with this. To use this new API, you simply need to define a couple of dictionaries (``_resources_to_share`` and ``_needed_resources``) in your class. Then, when the ``prepare_simulation`` method of your simulation is called, the shared variables get set up automatically.
+
+Making resources available to other modules
+-------------------------------------------
+
+In order to tell other :class:`turbopy.core.PhyiscsModules` about resources that you want to share, just add them to the member variable ``_resources_to_share`` in the ``__init__`` method. For example, the following function will share the variables ``self.position`` and ``self.momentum``::
+
+    def __init__(self, owner: Simulation, input_data: dict):
+        super().__init__(owner, input_data)
+        self.position = np.zeros((1, 3))
+        self.momentum = np.zeros((1, 3))
+
+        self._resources_to_share = {"position": self.position,
+                                    "momentum": self.momentum}
+
+Note that the variables that you want to share need to be defined before they can be added to the ``_resources_to_share`` dictionary. Also, make sure that they are *mutable* variables, otherwise other modules won't see any changes that you make to them during the simulation.
+
+
+Looking for shared resources
+----------------------------
+
+If your module needs access to a variable that is being shared from a different module, you use the member variable ``_needed_resources``. In this example, the data shared by the example above will be saved. ::
+
+    def __init__(self, owner: Simulation, input_data: dict):
+        super().__init__(owner, input_data)
+        self._needed_resources = {"position": "x",
+                                  "momentum": "p"}
+
+This will create the variables ``self.x`` and ``self.p``, which will point to the position and momentum data shared by the second module.

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: turbopy
 channels:
         - defaults
 dependencies:
-        - python=3.7
+        - python>=3.7
         - numpy
         - scipy
         - xarray

--- a/tests/fixtures/block_on_spring/block_on_spring.py
+++ b/tests/fixtures/block_on_spring/block_on_spring.py
@@ -15,12 +15,11 @@ class BlockOnSpring(PhysicsModule):
         self.spring_constant = input_data.get('spring_constant', 1)
         self.push = owner.find_tool_by_name(input_data["pusher"]).push
 
+        self._resources_to_share = {"Block:position": self.position,
+                                    "Block:momentum": self.momentum}
+
     def initialize(self):
         self.position[:] = np.array(self._input_data["x0"])
-
-    def exchange_resources(self):
-        self.publish_resource({"Block:position": self.position})
-        self.publish_resource({"Block:momentum": self.momentum})
 
     def update(self):
         self.push(self.position, self.momentum,
@@ -34,9 +33,7 @@ class BlockDiagnostic(Diagnostic):
         self.component = input_data.get("component", 1)
         self.outputter = None
 
-    def inspect_resource(self, resource):
-        if "Block:" + self.component in resource:
-            self.data = resource["Block:" + self.component]
+        self._needed_resources = {"Block:" + self.component: "data"}
 
     def diagnose(self):
         self.outputter.diagnose(self.data[0, :])

--- a/tests/fixtures/block_on_spring/block_on_spring.py
+++ b/tests/fixtures/block_on_spring/block_on_spring.py
@@ -41,7 +41,7 @@ class BlockDiagnostic(Diagnostic):
     def initialize(self):
         diagnostic_size = (self._owner.clock.num_steps + 1, 3)
         self.outputter = CSVOutputUtility(self._input_data["filename"],
-            diagnostic_size)
+                                          diagnostic_size)
 
     def finalize(self):
         self.diagnose()
@@ -134,7 +134,7 @@ def bos_run():
         "Tools": {
             "Leapfrog": {},
             "BlockForwardEuler": {},
-            "BackwardEuler":{}
+            "BackwardEuler": {}
         },
         "Diagnostics": {
             # default values come first

--- a/tests/fixtures/particle_in_field/particle_in_field.py
+++ b/tests/fixtures/particle_in_field/particle_in_field.py
@@ -1,9 +1,5 @@
-from dataclasses import dataclass
 import numpy as np
-from numpy.lib.twodim_base import diag
 import xarray as xr
-# TODO: add tests for plotting
-# import matplotlib.pyplot as plt
 import pytest
 
 from turbopy import Simulation, PhysicsModule, Diagnostic
@@ -26,17 +22,17 @@ class EMWave(PhysicsModule):
 
         self.omega = input_data["omega"]
         self.k = self.omega / self.c
-    
+
+        self._resources_to_share = {"EMField:E": self.E}
+
     def initialize(self):
         phase = - self.omega * 0 + self.k * (self._owner.grid.r - 0.5)
         self.E[:] = self.E0 * np.cos(2 * np.pi * phase)
 
     def update(self):
-        phase = - self.omega * self._owner.clock.time + self.k * (self._owner.grid.r - 0.5)
+        phase = (- self.omega * self._owner.clock.time
+                 + self.k * (self._owner.grid.r - 0.5))
         self.E[:] = self.E0 * np.cos(2 * np.pi * phase)
-        
-    def exchange_resources(self):
-        self.publish_resource({"EMField:E": self.E})
 
 
 class ChargedParticle(PhysicsModule):
@@ -51,14 +47,9 @@ class ChargedParticle(PhysicsModule):
         self.charge = 1.6022e-19
         self.mass = 9.1094e-31
         self.push = owner.find_tool_by_name(input_data["pusher"]).push
-        
-    def exchange_resources(self):
-        self.publish_resource({"ChargedParticle:position": self.position})
-        self.publish_resource({"ChargedParticle:momentum": self.momentum})
-    
-    def inspect_resource(self, resource):
-        if "EMField:E" in resource:
-            self.E = resource["EMField:E"]    
+        self._needed_resources = {"EMField:E": "E"}
+        self._resources_to_share = {"ChargedParticle:position": self.position,
+                                    "ChargedParticle:momentum": self.momentum}
 
     def update(self):
         E = np.array([0, self.interp_field(self.E), 0])
@@ -72,11 +63,8 @@ class ParticleDiagnostic(Diagnostic):
         self.component = input_data["component"]
         self.output_function = None
         self.outputter = None
+        self._needed_resources = {"ChargedParticle:"+self.component: "data"}
 
-    def inspect_resource(self, resource):
-        if "ChargedParticle:" + self.component in resource:
-            self.data = resource["ChargedParticle:" + self.component]
-    
     def diagnose(self):
         self.outputter.diagnose(self.data[0, :])
 
@@ -84,7 +72,7 @@ class ParticleDiagnostic(Diagnostic):
         # setup output method
         diagnostic_size = (self._owner.clock.num_steps + 1, 3)
         self.outputter = CSVOutputUtility(self._input_data["filename"],
-            diagnostic_size)
+                                          diagnostic_size)
 
     def finalize(self):
         self.diagnose()
@@ -94,15 +82,14 @@ class ParticleDiagnostic(Diagnostic):
         print(data)
 
 
-
 class ForwardEuler(ComputeTool):
     def __init__(self, owner: Simulation, input_data: dict):
         super().__init__(owner, input_data)
         self.dt = None
-        
+
     def initialize(self):
         self.dt = self._owner.clock.dt
-    
+
     def push(self, position, momentum, charge, mass, E, B):
         p0 = momentum.copy()
         momentum[:] = momentum + self.dt * E * charge
@@ -114,10 +101,8 @@ def pif_sim():
     PhysicsModule.register("EMWave", EMWave)
     PhysicsModule.register("ChargedParticle", ChargedParticle)
     Diagnostic.register("ParticleDiagnostic", ParticleDiagnostic)
-#     Diagnostic.register("FieldPlottingDiagnostic", FieldPlottingDiagnostic)
     ComputeTool.register("ForwardEuler", ForwardEuler)
     input_file = "tests/fixtures/particle_in_field/particle_in_field.toml"
     sim = construct_simulation_from_toml(input_file)
-    
-    # print(sim.input_data['Diagnostics'])
+
     return sim

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,6 +118,10 @@ def test_gridless_simulation(tmp_path):
         assert str(w[-1].message) == "No Grid Found."
 
 
+def test_resources_in_inspect_resource_when_modules_and_diagnostics_are_cycled(simple_sim):
+    pass
+
+
 def test_read_clock_from_input_should_set_clock_attr_when_called(simple_sim):
     """Test read_clock_from_input method in Simulation class"""
     simple_sim.read_clock_from_input()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -120,9 +120,9 @@ def test_gridless_simulation(tmp_path):
 
 def test_subclass(simple_sim):
     """Test if subclasses are contained in Simulation"""
-    assert issubclass(turbopy.core.ExampleModule, PhysicsModule)
-    assert issubclass(turbopy.core.ExampleDiagnostic, Diagnostic)
-    assert issubclass(turbopy.core.ExampleTool, ComputeTool)
+    assert issubclass(ExampleModule, PhysicsModule)
+    assert issubclass(ExampleDiagnostic, Diagnostic)
+    assert issubclass(ExampleTool, ComputeTool)
 
 
 def test_resources_in_inspect_resource_when_modules_and_diagnostics_are_cycled(simple_sim):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,8 +118,20 @@ def test_gridless_simulation(tmp_path):
         assert str(w[-1].message) == "No Grid Found."
 
 
+def test_subclass(simple_sim):
+    """Test if subclasses are contained in Simulation"""
+    assert issubclass(turbopy.core.ExampleModule, PhysicsModule)
+    assert issubclass(turbopy.core.ExampleDiagnostic, Diagnostic)
+    assert issubclass(turbopy.core.ExampleTool, ComputeTool)
+
+
 def test_resources_in_inspect_resource_when_modules_and_diagnostics_are_cycled(simple_sim):
-    pass
+    """Calls in the Example Physics Module or Diagnostic and checks the resources in the resource dictionary"""
+    # Stuck on this
+    # resources_in_physics_module = ExampleModule.inspect_resource(simple_sim, resource: dict):
+    # resources_in_diagnostic = ExampleDiagnostic.inspect_resource(simple_sim, resource: dict):
+    # assert resources_in_physics_module is not None
+    # assert resources_in_diagnostic is not None
 
 
 def test_read_clock_from_input_should_set_clock_attr_when_called(simple_sim):
@@ -181,7 +193,7 @@ def test_turn_back_should_turn_back_time_when_called(simple_sim):
 
 
 def test_read_modules_from_input_should_set_modules_attr_when_called(simple_sim):
-    """Test read_modules_from_input method in Simulation calss"""
+    """Test read_modules_from_input method in Simulation class"""
     simple_sim.read_modules_from_input()
     assert simple_sim.physics_modules[0]._owner == simple_sim
     assert simple_sim.physics_modules[0]._input_data == {"name": "ExampleModule"}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -98,6 +98,7 @@ def test_read_grid_from_input_should_set_grid_attr_when_called(simple_sim):
     assert simple_sim.grid.r_max == 1
 
 
+# Test the old sharing API
 class ReceivingModule(PhysicsModule):
     """Example PhysicsModule subclass for tests"""
     def __init__(self, owner: Simulation, input_data: dict):
@@ -157,7 +158,63 @@ def test_that_shared_resource_is_available_in_initialize(share_sim):
     share_sim.prepare_simulation()
     assert len(share_sim.physics_modules) == 2
     assert len(share_sim.physics_modules[0].data) == 1
-    assert id(share_sim.physics_modules[0].data) == id(share_sim.physics_modules[1].data)
+    assert (id(share_sim.physics_modules[0].data)
+            == id(share_sim.physics_modules[1].data))
+
+
+# Test the new sharing API
+class ReceivingModuleV2(PhysicsModule):
+    """Example PhysicsModule subclass for tests"""
+    def __init__(self, owner: Simulation, input_data: dict):
+        super().__init__(owner, input_data)
+        self.data = None
+        self._needed_resources = {'shared': 'data'}
+
+    def initialize(self):
+        # if resources are shared correctly, then this list will be accessible
+        print(f'The first data item is {self.data[0]}')
+
+    def update(self):
+        pass
+
+
+class SharingModuleV2(PhysicsModule):
+    """Example PhysicsModule subclass for tests"""
+    def __init__(self, owner: Simulation, input_data: dict):
+        super().__init__(owner, input_data)
+        self.data = ['test']
+        self._resources_to_share = {'shared': self.data}
+
+    def update(self):
+        pass
+
+
+PhysicsModule.register("ReceivingV2", ReceivingModuleV2)
+PhysicsModule.register("SharingV2", SharingModuleV2)
+
+
+# Simulation class test methods
+@pytest.fixture(name='share_sim_V2')
+def shared_simulation_V2_fixture():
+    """Pytest fixture for basic simulation class"""
+    dic = {"Grid": {"N": 2, "r_min": 0, "r_max": 1},
+           "Clock": {"start_time": 0,
+                     "end_time": 10,
+                     "num_steps": 1},
+           "PhysicsModules": {
+               "ReceivingV2": {},
+               "SharingV2": {}
+           },
+           }
+    return Simulation(dic)
+
+
+def test_that_V2_shared_resource_is_available_in_initialize(share_sim_V2):
+    share_sim_V2.prepare_simulation()
+    assert len(share_sim_V2.physics_modules) == 2
+    assert len(share_sim_V2.physics_modules[0].data) == 1
+    assert (id(share_sim_V2.physics_modules[0].data)
+            == id(share_sim_V2.physics_modules[1].data))
 
 
 def test_gridless_simulation(tmp_path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,6 +153,11 @@ def test_that_simulation_is_created(share_sim):
     assert share_sim.physics_modules == []
 
 
+def test_that_v1_sharing_is_deprecated(share_sim):
+    with pytest.deprecated_call():
+        share_sim.prepare_simulation()
+
+
 def test_that_shared_resource_is_available_in_initialize(share_sim):
     share_sim.prepare_simulation()
     assert len(share_sim.physics_modules) == 2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -134,7 +134,6 @@ PhysicsModule.register("Receiving", ReceivingModule)
 PhysicsModule.register("Sharing", SharingModule)
 
 
-# Simulation class test methods
 @pytest.fixture(name='share_sim')
 def shared_simulation_fixture():
     """Pytest fixture for basic simulation class"""
@@ -193,7 +192,6 @@ PhysicsModule.register("ReceivingV2", ReceivingModuleV2)
 PhysicsModule.register("SharingV2", SharingModuleV2)
 
 
-# Simulation class test methods
 @pytest.fixture(name='share_sim_V2')
 def shared_simulation_V2_fixture():
     """Pytest fixture for basic simulation class"""
@@ -215,6 +213,43 @@ def test_that_V2_shared_resource_is_available_in_initialize(share_sim_V2):
     assert len(share_sim_V2.physics_modules[0].data) == 1
     assert (id(share_sim_V2.physics_modules[0].data)
             == id(share_sim_V2.physics_modules[1].data))
+
+
+# Test V1/V2 interaction
+def test_that_V1V2_shared_resource_is_available_in_initialize():
+    config = {
+        "Grid": {"N": 2, "r_min": 0, "r_max": 1},
+        "Clock": {"start_time": 0,
+                  "end_time": 10,
+                  "num_steps": 1},
+        "PhysicsModules": {
+            "ReceivingV2": {},
+            "Sharing": {}
+            },
+        }
+    sim = Simulation(config)
+    sim.prepare_simulation()
+    assert len(sim.physics_modules) == 2
+    assert len(sim.physics_modules[0].data) == 1
+    assert (id(sim.physics_modules[0].data) == id(sim.physics_modules[1].data))
+
+
+def test_that_V2V1_shared_resource_is_available_in_initialize():
+    config = {
+        "Grid": {"N": 2, "r_min": 0, "r_max": 1},
+        "Clock": {"start_time": 0,
+                  "end_time": 10,
+                  "num_steps": 1},
+        "PhysicsModules": {
+            "Receiving": {},
+            "SharingV2": {}
+            },
+        }
+    sim = Simulation(config)
+    sim.prepare_simulation()
+    assert len(sim.physics_modules) == 2
+    assert len(sim.physics_modules[0].data) == 1
+    assert (id(sim.physics_modules[0].data) == id(sim.physics_modules[1].data))
 
 
 def test_gridless_simulation(tmp_path):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -192,6 +192,9 @@ PhysicsModule.register("ReceivingV2", ReceivingModuleV2)
 PhysicsModule.register("SharingV2", SharingModuleV2)
 
 
+# Still need to add tests for the Diagnostics with the new API
+
+
 @pytest.fixture(name='share_sim_V2')
 def shared_simulation_V2_fixture():
     """Pytest fixture for basic simulation class"""
@@ -285,15 +288,6 @@ def test_subclass(simple_sim):
     assert issubclass(ExampleModule, PhysicsModule)
     assert issubclass(ExampleDiagnostic, Diagnostic)
     assert issubclass(ExampleTool, ComputeTool)
-
-
-def test_resources_in_inspect_resource_when_modules_and_diagnostics_are_cycled(simple_sim):
-    """Calls in the Example Physics Module or Diagnostic and checks the resources in the resource dictionary"""
-    # Stuck on this
-    # resources_in_physics_module = ExampleModule.inspect_resource(simple_sim, resource: dict):
-    # resources_in_diagnostic = ExampleDiagnostic.inspect_resource(simple_sim, resource: dict):
-    # assert resources_in_physics_module is not None
-    # assert resources_in_diagnostic is not None
 
 
 def test_read_clock_from_input_should_set_clock_attr_when_called(simple_sim):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -218,43 +218,6 @@ def test_that_V2_shared_resource_is_available_in_initialize(share_sim_V2):
             == id(share_sim_V2.physics_modules[1].data))
 
 
-# Test V1/V2 interaction
-def test_that_V1V2_shared_resource_is_available_in_initialize():
-    config = {
-        "Grid": {"N": 2, "r_min": 0, "r_max": 1},
-        "Clock": {"start_time": 0,
-                  "end_time": 10,
-                  "num_steps": 1},
-        "PhysicsModules": {
-            "ReceivingV2": {},
-            "Sharing": {}
-            },
-        }
-    sim = Simulation(config)
-    sim.prepare_simulation()
-    assert len(sim.physics_modules) == 2
-    assert len(sim.physics_modules[0].data) == 1
-    assert (id(sim.physics_modules[0].data) == id(sim.physics_modules[1].data))
-
-
-def test_that_V2V1_shared_resource_is_available_in_initialize():
-    config = {
-        "Grid": {"N": 2, "r_min": 0, "r_max": 1},
-        "Clock": {"start_time": 0,
-                  "end_time": 10,
-                  "num_steps": 1},
-        "PhysicsModules": {
-            "Receiving": {},
-            "SharingV2": {}
-            },
-        }
-    sim = Simulation(config)
-    sim.prepare_simulation()
-    assert len(sim.physics_modules) == 2
-    assert len(sim.physics_modules[0].data) == 1
-    assert (id(sim.physics_modules[0].data) == id(sim.physics_modules[1].data))
-
-
 def test_gridless_simulation(tmp_path):
     """Test a gridless simulation"""
     dic = {"Clock": {"start_time": 0,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -64,6 +64,7 @@ def field_fixt_npy(tmp_path):
     field = sim.diagnostics[0]
     return field
 
+
 # Test methods for FieldDiagnostic class with csv file
 def test_init_should_create_class_instance_when_called(simple_field_csv):
     """Tests init method in FieldDiagnostic class"""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -3,7 +3,21 @@ Tests for the diagonstics.py file
 """
 import pytest
 import numpy as np
-from turbopy.core import Simulation
+from turbopy.core import Simulation, PhysicsModule
+
+
+class SharedField(PhysicsModule):
+    """Example PhysicsModule subclass for tests"""
+    def __init__(self, owner: Simulation, input_data: dict):
+        super().__init__(owner, input_data)
+        self.data = np.linspace(0, 1, 2)
+        self._resources_to_share = {'Field': self.data}
+
+    def update(self):
+        pass
+
+
+PhysicsModule.register("SharedField", SharedField)
 
 
 @pytest.fixture(name='simple_field_csv')
@@ -13,8 +27,7 @@ def field_fixt_csv(tmp_path):
                "Clock": {"start_time": 0,
                          "end_time": 10,
                          "num_steps": 100},
-               "Tools": {"ExampleTool": {}},
-               "PhysicsModules": {"ExampleModule": {}},
+               "PhysicsModules": {"SharedField": {}},
                "Diagnostics": {
                    "directory": f"{tmp_path}/default_output",
                    # "clock": {},
@@ -42,8 +55,7 @@ def field_fixt_npy(tmp_path):
                "Clock": {"start_time": 0,
                          "end_time": 10,
                          "num_steps": 100},
-               "Tools": {"ExampleTool": {}},
-               "PhysicsModules": {"ExampleModule": {}},
+               "PhysicsModules": {"SharedField": {}},
                "Diagnostics": {
                    "directory": f"{tmp_path}/default_output",
                    # "clock": {},
@@ -72,12 +84,11 @@ def test_init_should_create_class_instance_when_called(simple_field_csv):
     assert simple_field_csv.output == "csv"
     assert simple_field_csv.field is None
     assert simple_field_csv.outputter is None
-    assert simple_field_csv.field_was_found is False
 
 
 def test_check_step_should_update_last_dump_after_dump_interval_has_passed(simple_field_csv):
     """Tests check_step method in FieldDiagnostic class"""
-    simple_field_csv.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_csv._owner.prepare_simulation()
     simple_field_csv.initialize()
     simple_field_csv._owner.clock.time = 1
     simple_field_csv.dump_handler.perform_action(simple_field_csv._owner.clock.time)
@@ -86,32 +97,22 @@ def test_check_step_should_update_last_dump_after_dump_interval_has_passed(simpl
 
 def test_initialize_should_set_remaining_parameters_when_called(simple_field_csv):
     """Tests initialize method in FieldDiagnostic class for declared attributes"""
-    with pytest.raises(RuntimeError):
-        assert simple_field_csv.initialize()
-    simple_field_csv.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_csv._owner.prepare_simulation()
     simple_field_csv.initialize()
     assert simple_field_csv.diagnostic_size == (11, 2)
 
 
 def test_initialize_should_set_outputter_parameters_when_called(simple_field_csv, tmp_path):
-    simple_field_csv.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_csv._owner.prepare_simulation()
     simple_field_csv.initialize()
     assert simple_field_csv.outputter._filename == f"{tmp_path}/default_output/output.csv"
     assert np.allclose(simple_field_csv.outputter._buffer, np.zeros((11, 2)))
     assert simple_field_csv.outputter._buffer_index == 0
 
 
-def test_inspect_resource_should_assign_field_attribute_if_field_name_in_resource(simple_field_csv):
-    """Tests inspect_resource method in FieldDiagnostic class"""
-    array_to_share = np.linspace(0, 1, 2)
-    simple_field_csv.inspect_resource({"Field": array_to_share})
-    assert simple_field_csv.field_was_found is True
-    assert simple_field_csv.field is array_to_share
-
-
 def test_csv_diagnose_should_append_data_to_csv_when_called(simple_field_csv):
     """Tests csv_diagnose method in FieldDiagnostic class"""
-    simple_field_csv.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_csv._owner.prepare_simulation()
     simple_field_csv.initialize()
     simple_field_csv.do_diagnostic()
     assert np.allclose(simple_field_csv.outputter._buffer[
@@ -128,12 +129,11 @@ def test_init_should_create_class_instance_when_called_npy(simple_field_npy):
     assert simple_field_npy.output == "npy"
     assert simple_field_npy.field is None
     assert simple_field_npy.diagnostic_size is None
-    assert simple_field_npy.field_was_found is False
 
 
 def test_check_step_should_update_last_dump_after_dump_interval_has_passed_npy(simple_field_npy):
     """Tests check_step method in FieldDiagnostic class"""
-    simple_field_npy.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_npy._owner.prepare_simulation()
     simple_field_npy.initialize()
     simple_field_npy._owner.clock.time = 1
     simple_field_npy.dump_handler.perform_action(simple_field_npy._owner.clock.time)
@@ -142,33 +142,23 @@ def test_check_step_should_update_last_dump_after_dump_interval_has_passed_npy(s
 
 def test_initialize_should_set_remaining_parameters_when_called_npy(simple_field_npy):
     """Tests initialize method in FieldDiagnostic class for declared attributes"""
-    with pytest.raises(RuntimeError):
-        assert simple_field_npy.initialize()
-    simple_field_npy.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_npy._owner.prepare_simulation()
     simple_field_npy.initialize()
     assert simple_field_npy.dump_interval == 1
     assert simple_field_npy.diagnostic_size == (11, 2)
 
 
 def test_initialize_should_set_outputter_parameters_when_called_npy(simple_field_npy, tmp_path):
-    simple_field_npy.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_npy._owner.prepare_simulation()
     simple_field_npy.initialize()
     assert simple_field_npy.outputter._filename == f"{tmp_path}/default_output/output.npy"
     assert np.allclose(simple_field_npy.outputter._buffer, np.zeros((11, 2)))
     assert simple_field_npy.outputter._buffer_index == 0
 
 
-def test_inspect_resource_should_assign_field_attribute_if_field_name_in_resource_npy(simple_field_npy):
-    """Tests inspect_resource method in FieldDiagnostic class"""
-    array_to_share = np.linspace(0, 1, 2)
-    simple_field_npy.inspect_resource({"Field": array_to_share})
-    assert simple_field_npy.field_was_found is True
-    assert simple_field_npy.field is array_to_share
-
-
 def test_csv_diagnose_should_append_data_to_csv_when_called_npy(simple_field_npy):
     """Tests npy_diagnose method in FieldDiagnostic class"""
-    simple_field_npy.inspect_resource({"Field": np.linspace(0, 1, 2)})
+    simple_field_npy._owner.prepare_simulation()
     simple_field_npy.initialize()
     simple_field_npy.do_diagnostic()
     assert np.allclose(simple_field_npy.outputter._buffer[

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -132,6 +132,8 @@ class Simulation:
         self.units = None
 
         self.input_data = input_data
+        
+        self.all_shared_resources = {}
 
     def run(self):
         """
@@ -196,9 +198,9 @@ class Simulation:
 
         print("Initializing PhysicsModules...")
         for m in self.physics_modules:
-            m.inspect_resources(self._owner_all_shared_resources)
-        for m in self.physics_modules:
             m.exchange_resources()
+        for m in self.physics_modules:
+            m.inspect_resource(self.all_shared_resources)
         for m in self.physics_modules:
             m.initialize()
 
@@ -415,17 +417,17 @@ class PhysicsModule(DynamicFactory):
         resource : `dict`
             resource dictionary to be shared
         """
-        for k, v in self._owner_all_shared_resources.items():
-            self._owner_all_shared_resources[k] = v
+        for k, v in resource.items():
+            self._owner.all_shared_resources[k] = v
 
         for k in resource.keys():
             print(f"Module {self.__class__.__name__} is sharing {k}")
-        for physics_module in self._owner.physics_modules:
-            physics_module.inspect_resource(resource)
+        # for physics_module in self._owner.physics_modules:
+        #     physics_module.inspect_resource(resource)
         for diagnostic in self._owner.diagnostics:
             diagnostic.inspect_resource(resource)
 
-    def inspect_resource(self, all_shared_resource: dict, resource: dict):
+    def inspect_resource(self, all_shared_resource: dict):
         """Method for accepting resources shared by other PhysicsModules
         If your subclass needs the data described by the key, now's
         their chance to save a pointer to the data.
@@ -437,9 +439,9 @@ class PhysicsModule(DynamicFactory):
         resource : `dict`
             resource dictionary to be shared
         """
-        if any(self._owner_all_shared_resource[i] == [] for i in self._owner_all_shared_resource):
+        if any(all_shared_resource[i] == [] for i in all_shared_resource):
             warnings.warn(f"Resource not found")
-            for k in self._owner_all_shared_resource.keys():
+            for k in all_shared_resource.keys():
                 print(f"Resource needed in Module {self.__class__.__name__} for {k}")
         else:
             print("All physics module resources found")
@@ -947,12 +949,12 @@ class Diagnostic(DynamicFactory):
             A dictionary containing references to data shared by other
             PhysicsModules.
         """
-        if any(resource[i] == [] for i in resource):
-            warnings.warn(f"Resource not found")
-            for k in resource.keys():
-                print(f"Resource needed in Diagnostic {self.__class__.__name__} for {k}")
-        else:
-            print("All diagnostic resources found")
+        # if any(resource[i] == [] for i in resource):
+        #     warnings.warn(f"Resource not found")
+        #     for k in resource.keys():
+        #         print(f"Resource needed in Diagnostic {self.__class__.__name__} for {k}")
+        # else:
+        #     print("All diagnostic resources found")
 
     def diagnose(self):
         """Perform diagnostic step

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -406,6 +406,8 @@ class PhysicsModule(DynamicFactory):
         self._module_type = None
         self._input_data = input_data
 
+        self._resources = {} #dictionary of all resources so we don't need to recalculate in inspect_resource (not sure if we want to do it this way)
+
     def publish_resource(self, resource: dict):
         """
         Method which implements the details of sharing resources
@@ -439,7 +441,7 @@ class PhysicsModule(DynamicFactory):
         resource : `dict`
             resource dictionary to be shared
         """
-        if any(all_shared_resource[i] == [] for i in all_shared_resource):
+        if any(all_shared_resource[i] == [] for i in self._resources):
             warnings.warn(f"Resource not found")
             for k in all_shared_resource.keys():
                 print(f"Resource needed in Module {self.__class__.__name__} for {k}")
@@ -460,6 +462,7 @@ class PhysicsModule(DynamicFactory):
         shared = {f'{self.__class__.__name__}_{attribute}': value for attribute, value
                   in self.__dict__.items()
                   if not attribute.startswith('_')}
+        self.resources = shared
         self.publish_resource(shared)
 
     def update(self):
@@ -949,12 +952,12 @@ class Diagnostic(DynamicFactory):
             A dictionary containing references to data shared by other
             PhysicsModules.
         """
-        # if any(resource[i] == [] for i in resource):
-        #     warnings.warn(f"Resource not found")
-        #     for k in resource.keys():
-        #         print(f"Resource needed in Diagnostic {self.__class__.__name__} for {k}")
-        # else:
-        #     print("All diagnostic resources found")
+        if any(resource[i] == [] for i in resource):
+            warnings.warn(f"Resource not found")
+            for k in resource.keys():
+                print(f"Resource needed in Diagnostic {self.__class__.__name__} for {k}")
+        else:
+            print("All diagnostic resources found")
 
     def diagnose(self):
         """Perform diagnostic step

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -433,7 +433,7 @@ class PhysicsModule(DynamicFactory):
             for k in resource.keys():
                 print(f"Resource needed in Module {self.__class__.__name__} for {k}")
         else:
-            print("All resources found")
+            print("All physics module resources found")
 
     def exchange_resources(self):
         """Main method for sharing resources with other
@@ -943,7 +943,7 @@ class Diagnostic(DynamicFactory):
             for k in resource.keys():
                 print(f"Resource needed in Diagnostic {self.__class__.__name__} for {k}")
         else:
-            print("All resources found")
+            print("All diagnostic resources found")
 
     def diagnose(self):
         """Perform diagnostic step

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -231,8 +231,8 @@ class Simulation:
                     params = [params]
                 for tool in params:
                     tool["type"] = tool_name
-                    self.compute_tools.append(tool_class(owner=self, 
-                                                         input_data=tool)) 
+                    self.compute_tools.append(tool_class(owner=self,
+                                                         input_data=tool))
 
     def read_modules_from_input(self):
         """Construct :class:`PhysicsModule` instances based on input"""
@@ -291,7 +291,7 @@ class Simulation:
     def find_tool_by_name(self, tool_name: str, custom_name: str = None):
         """Returns the :class:`ComputeTool` associated with the
         given name"""
-        tools = [t for t in self.compute_tools if t.name == tool_name 
+        tools = [t for t in self.compute_tools if t.name == tool_name
                  and t.custom_name == custom_name]
         if len(tools) == 1:
             return tools[0]
@@ -307,6 +307,7 @@ class DynamicFactory(ABC):
     This base class provides a dynamic factory pattern functionality to
     classes that derive from this.
     """
+
     @property
     @abstractmethod
     def _factory_type_name(self):
@@ -427,7 +428,12 @@ class PhysicsModule(DynamicFactory):
         resource : `dict`
             resource dictionary to be shared
         """
-        pass
+        if any(resource[i] == [] for i in resource):
+            warnings.warn(f"Resource not found")
+            for k in resource.keys():
+                print(f"Resource needed in Module {self.__class__.__name__} for {k}")
+        else:
+            print("All resources found")
 
     def exchange_resources(self):
         """Main method for sharing resources with other
@@ -586,8 +592,8 @@ class SimulationClock:
         if "num_steps" in input_data:
             self.num_steps = input_data["num_steps"]
             self.dt = (
-                (input_data["end_time"] - input_data["start_time"])
-                / input_data["num_steps"])
+                    (input_data["end_time"] - input_data["start_time"])
+                    / input_data["num_steps"])
         elif "dt" in input_data:
             self.dt = input_data["dt"]
             self.num_steps = (self.end_time - self.start_time) / self.dt
@@ -602,13 +608,13 @@ class SimulationClock:
         self.time = self.start_time + self.dt * self.this_step
         if self.print_time:
             print(f"t = {self.time:0.4e}")
-    
+
     def turn_back(self, num_steps=1):
         """Set the time back `num_steps` time steps"""
         self.this_step = self.this_step - num_steps
         self.time = self.start_time + self.dt * self.this_step
         if self.print_time:
-            print(f"t = {self.time}")        
+            print(f"t = {self.time}")
 
     def is_running(self):
         """Check if time is less than end time"""
@@ -660,6 +666,7 @@ class Grid:
         Inverse of coordinate values at each Grid point,
         1/:class:`Grid.r`.
     """
+
     def __init__(self, input_data: dict):
         self._input_data = input_data
         self.r_min = None
@@ -849,17 +856,17 @@ class Grid:
 
     def set_cartesian_volumes(self):
         self.cell_volumes = self.cell_edges[1:] - self.cell_edges[:-1]
-        self.inverse_cell_volumes = 1./self.cell_volumes
+        self.inverse_cell_volumes = 1. / self.cell_volumes
 
     def set_cylindrical_volumes(self):
         scratch = self.cell_edges ** 2
         self.cell_volumes = np.pi * (scratch[1:] - scratch[:-1])
-        self.inverse_cell_volumes = 1./self.cell_volumes
+        self.inverse_cell_volumes = 1. / self.cell_volumes
 
     def set_spherical_volumes(self):
         scratch = self.cell_edges ** 3
-        self.cell_volumes = 4/3 * np.pi * (scratch[1:] - scratch[:-1])
-        self.inverse_cell_volumes = 1./self.cell_volumes
+        self.cell_volumes = 4 / 3 * np.pi * (scratch[1:] - scratch[:-1])
+        self.inverse_cell_volumes = 1. / self.cell_volumes
 
     def set_cartesian_areas(self):
         self.interface_areas = np.ones_like(self.cell_edges)
@@ -931,7 +938,12 @@ class Diagnostic(DynamicFactory):
             A dictionary containing references to data shared by other
             PhysicsModules.
         """
-        pass
+        if any(resource[i] == [] for i in resource):
+            warnings.warn(f"Resource not found")
+            for k in resource.keys():
+                print(f"Resource needed in Diagnostic {self.__class__.__name__} for {k}")
+        else:
+            print("All resources found")
 
     def diagnose(self):
         """Perform diagnostic step

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -196,6 +196,8 @@ class Simulation:
 
         print("Initializing PhysicsModules...")
         for m in self.physics_modules:
+            m.inspect_resources(self._owner_all_shared_resources)
+        for m in self.physics_modules:
             m.exchange_resources()
         for m in self.physics_modules:
             m.initialize()
@@ -408,9 +410,14 @@ class PhysicsModule(DynamicFactory):
 
         Parameters
         ----------
+        all_shared_resources : `dict`
+            global dictionary of all the resources
         resource : `dict`
             resource dictionary to be shared
         """
+        for k, v in self._owner_all_shared_resources.items():
+            self._owner_all_shared_resources[k] = v
+
         for k in resource.keys():
             print(f"Module {self.__class__.__name__} is sharing {k}")
         for physics_module in self._owner.physics_modules:
@@ -418,19 +425,21 @@ class PhysicsModule(DynamicFactory):
         for diagnostic in self._owner.diagnostics:
             diagnostic.inspect_resource(resource)
 
-    def inspect_resource(self, resource: dict):
+    def inspect_resource(self, all_shared_resource: dict, resource: dict):
         """Method for accepting resources shared by other PhysicsModules
         If your subclass needs the data described by the key, now's
         their chance to save a pointer to the data.
 
         Parameters
         ----------
+        all_shared_resource : `dict`
+            global dictionary for all shared resources
         resource : `dict`
             resource dictionary to be shared
         """
-        if any(resource[i] == [] for i in resource):
+        if any(self._owner_all_shared_resource[i] == [] for i in self._owner_all_shared_resource):
             warnings.warn(f"Resource not found")
-            for k in resource.keys():
+            for k in self._owner_all_shared_resource.keys():
                 print(f"Resource needed in Module {self.__class__.__name__} for {k}")
         else:
             print("All physics module resources found")

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -133,7 +133,7 @@ class Simulation:
         self.units = None
 
         self.input_data = input_data
-        
+
         self.all_shared_resources = {}
 
         # set default values for optional
@@ -479,7 +479,9 @@ class PhysicsModule(DynamicFactory):
                 warnings.warn(f"Module {self.__class__.__name__} can't find"
                               f"needed resource {shared_name}")
             else:
-                self.__dict__[var_name] = self._owner.all_shared_resources[shared_name]
+                self.__dict__[var_name] = self._owner.all_shared_resources[
+                                              shared_name
+                                          ]
 
     def exchange_resources(self):
         """Main method for sharing resources with other
@@ -1007,7 +1009,9 @@ class Diagnostic(DynamicFactory):
                 warnings.warn(f"Diagnostic {self.__class__.__name__} can't "
                               f"find needed resource {shared_name}")
             else:
-                self.__dict__[var_name] = self._owner.all_shared_resources[shared_name]
+                self.__dict__[var_name] = self._owner.all_shared_resources[
+                                              shared_name
+                                          ]
 
     def diagnose(self):
         """Perform diagnostic step

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -978,6 +978,18 @@ class Diagnostic(DynamicFactory):
         # For example: {"Fields:E": "E"} will make self.E
         self._needed_resources = {}
 
+    def inspect_resource(self, resource: dict):
+        """Save references to data from other PhysicsModules
+        If your subclass needs the data described by the key, now's
+        their chance to save a reference to the data
+        Parameters
+        ----------
+        resource: `dict`
+            A dictionary containing references to data shared by other
+            PhysicsModules.
+        """
+        pass
+
     def inspect_resources(self):
         """Method for accepting resources shared by other PhysicsModules
         If your subclass needs the data described by the key, now's

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -487,17 +487,6 @@ class PhysicsModule(DynamicFactory):
         pass
 
     def inspect_resources(self):
-        """Method for accepting resources shared by other PhysicsModules
-        If your subclass needs the data described by the key, now's
-        their chance to save a pointer to the data.
-
-        Parameters
-        ----------
-        all_shared_resource : `dict`
-            global dictionary for all shared resources
-        resource : `dict`
-            resource dictionary to be shared
-        """
         for shared_name, var_name in self._needed_resources.items():
             if shared_name not in self._owner.all_shared_resources:
                 warnings.warn(f"Module {self.__class__.__name__} can't find"
@@ -1028,17 +1017,6 @@ class Diagnostic(DynamicFactory):
         pass
 
     def inspect_resources(self):
-        """Method for accepting resources shared by other PhysicsModules
-        If your subclass needs the data described by the key, now's
-        their chance to save a pointer to the data.
-
-        Parameters
-        ----------
-        all_shared_resource : `dict`
-            global dictionary for all shared resources
-        resource : `dict`
-            resource dictionary to be shared
-        """
         for shared_name, var_name in self._needed_resources.items():
             if shared_name not in self._owner.all_shared_resources:
                 warnings.warn(f"Diagnostic {self.__class__.__name__} can't "

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -405,6 +405,17 @@ class PhysicsModule(DynamicFactory):
         Registered derived ComputeTool classes.
     _factory_type_name : `str`
         Type of PhysicsModule child class.
+    _needed_resources: `dict`
+        Dictionary that lists shared resources that this module
+        needs. Format is `{shared_key: variable_name}`, where
+        `shared_key` is a string with the name of needed resource,
+        and `variable_name` is a string to use when saving this
+        variable. For example: {"Fields:E": "E"} will make `self.E`.
+    _resources_to_share: `dict`
+        Dictionary that lists shared resources that this module
+        is sharing to others. Format is `{shared_key: variable}`, where
+        `shared_key` is a string with the name of resource to share,
+        and `variable` is the data to be shared.
 
     Notes
     -----
@@ -437,7 +448,11 @@ class PhysicsModule(DynamicFactory):
         self._needed_resources = {}
 
     def publish_resource(self, resource: dict):
-        """
+        """**Deprecated**
+
+        *This method is only here for backwards compatability. New
+        code should use the ``_resources_to_share`` dictionary.*
+
         Method which implements the details of sharing resources
         Parameters
         ----------
@@ -456,7 +471,12 @@ class PhysicsModule(DynamicFactory):
             diagnostic.inspect_resource(resource)
 
     def inspect_resource(self, resource: dict):
-        """Method for accepting resources shared by other PhysicsModules
+        """**Deprecated**
+
+        *This method is only here for backwards compatability. New
+        code should use the ``_needed_resources`` dictionary.*
+
+        Method for accepting resources shared by other PhysicsModules
         If your subclass needs the data described by the key, now's
         their chance to save a pointer to the data.
         Parameters
@@ -970,6 +990,12 @@ class Diagnostic(DynamicFactory):
     _input_data: `dict`
         Dictionary that contains user defined parameters about this
         object such as its name.
+    _needed_resources: `dict`
+        Dictionary that lists shared resources that this module
+        needs. Format is `{shared_key: variable_name}`, where
+        `shared_key` is a string with the name of needed resource,
+        and `variable_name` is a string to use when saving this
+        variable. For example: {"Fields:E": "E"} will make `self.E`.
     """
 
     _factory_type_name = "Diagnostic"
@@ -985,7 +1011,12 @@ class Diagnostic(DynamicFactory):
         self._needed_resources = {}
 
     def inspect_resource(self, resource: dict):
-        """Save references to data from other PhysicsModules
+        """**Deprecated**
+
+        *This method is only here for backwards compatability. New
+        code should use the ``_needed_resources`` dictionary.*
+
+        Save references to data from other PhysicsModules
         If your subclass needs the data described by the key, now's
         their chance to save a reference to the data
         Parameters

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -315,7 +315,7 @@ class Simulation:
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.input_data})"
-    
+
     def gather_shared_resources(self, shared):
         for k, v in shared.items():
             if k in self.all_shared_resources:
@@ -436,6 +436,32 @@ class PhysicsModule(DynamicFactory):
         # For example: {"Fields:E": "E"} will make self.E
         self._needed_resources = {}
 
+    def publish_resource(self, resource: dict):
+        """
+        Method which implements the details of sharing resources
+        Parameters
+        ----------
+        resource : `dict`
+            resource dictionary to be shared
+        """
+        for k in resource.keys():
+            print(f"Module {self.__class__.__name__} is sharing {k}")
+        for physics_module in self._owner.physics_modules:
+            physics_module.inspect_resource(resource)
+        for diagnostic in self._owner.diagnostics:
+            diagnostic.inspect_resource(resource)
+
+    def inspect_resource(self, resource: dict):
+        """Method for accepting resources shared by other PhysicsModules
+        If your subclass needs the data described by the key, now's
+        their chance to save a pointer to the data.
+        Parameters
+        ----------
+        resource : `dict`
+            resource dictionary to be shared
+        """
+        pass
+
     def inspect_resources(self):
         """Method for accepting resources shared by other PhysicsModules
         If your subclass needs the data described by the key, now's
@@ -449,7 +475,7 @@ class PhysicsModule(DynamicFactory):
             resource dictionary to be shared
         """
         for shared_name, var_name in self._needed_resources.items():
-            if not shared_name in self._owner.all_shared_resources:
+            if shared_name not in self._owner.all_shared_resources:
                 warnings.warn(f"Module {self.__class__.__name__} can't find"
                               f"needed resource {shared_name}")
             else:

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -444,6 +444,10 @@ class PhysicsModule(DynamicFactory):
         resource : `dict`
             resource dictionary to be shared
         """
+        warnings.warn("The resource-sharing API has changed. "
+                      "Add to `self._resources_to_share` instead of "
+                      "calling `publish_resource`.",
+                      DeprecationWarning)
         for k in resource.keys():
             print(f"Module {self.__class__.__name__} is sharing {k}")
         for physics_module in self._owner.physics_modules:

--- a/turbopy/diagnostics.py
+++ b/turbopy/diagnostics.py
@@ -281,6 +281,7 @@ class PointDiagnostic(Diagnostic):
         self.outputter = None
         self.interval = self._input_data.get('write_interval', None)
         self.handler = None
+        self._needed_resources = {self.field_name: "field"}
 
     def diagnose(self):
         """
@@ -289,18 +290,6 @@ class PointDiagnostic(Diagnostic):
         self.outputter.diagnose(self.get_value(self.field))
         if self.handler:
             self.handler.perform_action(self._owner.clock.time)
-
-    def inspect_resource(self, resource):
-        """
-        Assign attribute field if field_name given in resource.
-
-        Parameters
-        ----------
-        resource : dict
-            Dictionary containing information of field_name to resource.
-        """
-        if self.field_name in resource:
-            self.field = resource[self.field_name]
 
     def initialize(self):
         """
@@ -361,8 +350,6 @@ class FieldDiagnostic(Diagnostic):
     diagnostic_size : (int, int), None
         Size of data set to be written to CSV file. First value is the
         number of time points. Second value is number of spatial points.
-    field_was_found : bool
-        Boolean representing if field was found in inspect_resource.
     """
     def __init__(self, owner: Simulation, input_data: dict):
         super().__init__(owner, input_data)
@@ -376,13 +363,15 @@ class FieldDiagnostic(Diagnostic):
         self.dump_handler = None
         self.dump_interval = self._input_data.get('dump_interval', None)
 
-        self.field_was_found = False
         self.outputter = None
         self.diagnostic_size = None
 
         # Set up handler for writing to file during the simulation
         self.write_handler = None
         self.write_interval = self._input_data.get('write_interval', None)
+
+        # Set up resource sharing
+        self._needed_resources = {self.field_name: "field"}
 
     def diagnose(self):
         self.dump_handler.perform_action(self._owner.clock.time)
@@ -398,20 +387,6 @@ class FieldDiagnostic(Diagnostic):
         else:
             self.outputter.diagnose(self.field)
 
-    def inspect_resource(self, resource):
-        """
-        Assign attribute field if field_name given in resource and
-        update boolean if field was found.
-
-        Parameters
-        ----------
-        resource : dict
-            Dictionary containing information of field_name to resource.
-        """
-        if self.field_name in resource:
-            self.field_was_found = True
-            self.field = resource[self.field_name]
-
     def initialize(self):
         """
         Initialize diagnostic_size and output function if provided as
@@ -419,9 +394,6 @@ class FieldDiagnostic(Diagnostic):
         :class:`CSVOutputUtility` class.
         """
         super().initialize()
-        if not self.field_was_found:
-            raise (RuntimeError(f"Diagnostic field {self.field_name}"
-                                " was not found"))
         self.diagnostic_size = (self._owner.clock.num_steps + 1,
                                 self.field.shape[0])
 
@@ -628,7 +600,6 @@ class HistoryDiagnostic(Diagnostic):
     def __init__(self, owner: Simulation, input_data: dict) -> None:
         super().__init__(owner, input_data)
         self._filename = input_data['filename']
-        self._data = {}
         self._traces = xr.Dataset()
         self._history_key_list = [t['name'] for t in input_data['traces']]
         self._handler = None
@@ -642,6 +613,9 @@ class HistoryDiagnostic(Diagnostic):
             self._num_outputs = int(np.ceil(
                 self._owner.clock.end_time / self._interval))
 
+        # get shared resources
+        self._needed_resources = {k: f'_data_{k}' for k in self._history_key_list}
+
     def diagnose(self):
         self._handler.perform_action(self._owner.clock.time)
 
@@ -651,7 +625,7 @@ class HistoryDiagnostic(Diagnostic):
 
         for name in self._history_key_list:
             # Note, use the ellipsis here to handle multidimensional data
-            self._traces[name]._variable._data[this_step, ...] = self._data[name]
+            self._traces[name]._variable._data[this_step, ...] = self.__dict__[f'_data_{name}']
 
     def initialize(self):
         # set up the time coordinate
@@ -666,14 +640,14 @@ class HistoryDiagnostic(Diagnostic):
 
         # set up the history traces
         for trace in self._input_data['traces']:
-            trace_data = self._data[trace['name']]
+            trace_data = self.__dict__[f'_data_{trace["name"]}']
 
             if isinstance(trace_data, xr.Dataset):
                 for item in trace_data:
                     # use the xarray API to add this to the dataset
                     self._traces[item] = trace_data[item].expand_dims(
                         {'timestep': self._traces.coords['timestep']}).copy(deep=True)
-                    self._data[item] = trace_data[item]
+                    self.__dict__[f'_data_{item}'] = trace_data[item]
                     self._history_key_list.append(item)
                 self._history_key_list.remove(trace['name'])
             else:
@@ -694,12 +668,6 @@ class HistoryDiagnostic(Diagnostic):
     def finalize(self):
         self._traces = self._traces.squeeze()  # remove unused dimensions
         self._traces.to_netcdf(self._filename, 'w')
-
-    def inspect_resource(self, resource: dict):
-        for item in self._history_key_list:
-            if item in resource:
-                self._data[item] = resource[item]
-
 
 
 Diagnostic.register("point", PointDiagnostic)

--- a/turbopy/diagnostics.py
+++ b/turbopy/diagnostics.py
@@ -375,7 +375,7 @@ class FieldDiagnostic(Diagnostic):
 
     def diagnose(self):
         self.dump_handler.perform_action(self._owner.clock.time)
-        if self.handler:
+        if self.write_handler:
             self.write_handler.perform_action(self._owner.clock.time)
 
     def do_diagnostic(self):


### PR DESCRIPTION
# Pull Request
## Description

Here's one possible "solution" to the sharing problem. I've made changes to the core classes (Simulation, PhysicsModule, and Diagnostic). I've also updated the block-on-spring example test so that it works with this new API.

In this approach, the "shared" resources are defined in custom PhysicsModules through two dictionaries: `_resources_to_share` and `_needed_resources`. The `inspect_resources` and `exchange_resources` functions have been changed. They now put the resources to share into the "global" shared dictionary, and then look in the global dictionary for the resources they need. 

I think an approach like this could help developers as they write new "apps", since there are just the two dictionaries to define. They would no longer need to call publish_resource, or overload any of the functions related to exchanging resources.

Additionally, (as we discussed before), this opens the door to simpler error handling, and also things like code that could create a visual "map" of which modules share data and which use the shared data.

Thoughts? 