### PR TITLE
Reduce cyclomatic complexity of prepare_simulation

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,19 +89,39 @@ def test_read_grid_from_input_should_set_grid_attr_when_called(simple_sim):
     assert simple_sim.grid.r_min == 0
     assert simple_sim.grid.r_max == 1
 
+class AdvancedModule(PhysicsModule):
+    """More complex PhysicsModule subclass for testing"""
+    def __init__(self, owner: Simulation, input_data : dict):
+        super().__init__(owner, input_data)
+        self.attr1 = 1.0
+        self.attr2 = 2.0
+        self.attr3 = 3.0
+    
+    def update(self):
+        pass
+    
+    def inspect_resource(self, resource: dict):
+        for attribute in resource:
+            self.__setattr__(attribute, resource[attribute])
+
+PhysicsModule.register("AdvancedModule", AdvancedModule)
+
 def test_prepare_simulation_physics_modules(simple_sim):
     """Tests that prepare_simulation correctly initializes the physics_modules"""
-    other_sim = Simulation(simple_sim.input_data)
-    assert id(simple_sim) != id(other_sim)
-    other_sim.read_modules_from_input()
-    for i in other_sim.physics_modules:
+    simple_sim_input = simple_sim.input_data
+    simple_sim_input["PhysicsModules"]["AdvancedModule"] = {}
+    first_sim = Simulation(simple_sim_input)
+    second_sim = Simulation(simple_sim_input)
+    assert id(first_sim) != id(second_sim)
+    first_sim.read_modules_from_input()
+    for i in first_sim.physics_modules:
         i.exchange_resources()
-    for j in other_sim.physics_modules:
+    for j in first_sim.physics_modules:
         j.initialize()
-    simple_sim.prepare_simulation()
-    for k in range(len(simple_sim.physics_modules)):
-        assert id(simple_sim.physics_modules[k]) != id(other_sim.physics_modules[k])
-        assert str(simple_sim.physics_modules[k]) == str(other_sim.physics_modules[k])
+    second_sim.prepare_simulation()
+    for k in range(len(first_sim.physics_modules)):
+        assert id(first_sim.physics_modules[k]) != id(second_sim.physics_modules[k])
+        assert str(first_sim.physics_modules[k]) == str(second_sim.physics_modules[k])
 
 def test_gridless_simulation(tmp_path):
     """Test a gridless simulation"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -107,17 +107,16 @@ def test_prepare_simulation_physics_modules(simple_sim):
     second_sim = Simulation(simple_sim_input)
     assert id(first_sim) != id(second_sim)
     first_sim.read_modules_from_input()
-    for i in first_sim.physics_modules:
-        i.exchange_resources()
+    for first_modules in first_sim.physics_modules:
+        first_modules.exchange_resources()
     for i in range (1,4):
         assert first_sim.physics_modules[0].__dict__[f"AdvancedModule_attr{i}"] == \
                first_sim.physics_modules[1].__dict__[f"attr{i}"]
-    for j in first_sim.physics_modules:
-        j.initialize()
+    for first_modules in first_sim.physics_modules:
+        first_modules.initialize()
     second_sim.prepare_simulation()
-    for k in range(len(first_sim.physics_modules)):
-        assert id(first_sim.physics_modules[k]) != id(second_sim.physics_modules[k])
-        assert str(first_sim.physics_modules[k]) == str(second_sim.physics_modules[k])
+    assert id(first_sim.physics_modules) != id(second_sim.physics_modules)
+    assert str(first_sim.physics_modules) == str(second_sim.physics_modules)
 
 def test_gridless_simulation(tmp_path):
     """Test a gridless simulation"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,17 +89,16 @@ def test_read_grid_from_input_should_set_grid_attr_when_called(simple_sim):
     assert simple_sim.grid.r_min == 0
     assert simple_sim.grid.r_max == 1
 
-def test_prepare_simulation(simple_sim):
-    """Tests that the prepare_simulation method operates the same as if the physics modules 
-    exchange resources and are initialized seperately"""
+def test_prepare_simulation_physics_modules(simple_sim):
+    """Tests that prepare_simulation correctly initializes the physics_modules"""
     other_sim = simple_sim
     simple_sim.prepare_simulation()
-    for m in other_sim.physics_modules:
-        m.exchange_resources()
-    for m in other_sim.physics_modules:
-        m.initialize()
-    for i in range(len(simple_sim.physics_modules)):
-        assert simple_sim.physics_modules[i] == other_sim.physics_modules[i]
+    for i in other_sim.physics_modules:
+        i.exchange_resources()
+    for j in other_sim.physics_modules:
+        j.initialize()
+    for k in range(len(simple_sim.physics_modules)):
+        assert simple_sim.physics_modules[k] == other_sim.physics_modules[k]
 
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,48 +109,45 @@ class AdvancedModule(PhysicsModule):
 
 PhysicsModule.register("AdvancedModule", AdvancedModule)
 
-def test_physics_module_exchange_resources_should_share_attributes(simple_sim):
+@pytest.fixture(name = "advanced_sim")
+def adv_sin_fixt(simple_sim):
+    simple_sim.input_data["PhysicsModules"]["AdvancedModule"] = {}
+    advanced_sim = Simulation(simple_sim.input_data)
+    advanced_sim.read_modules_from_input()
+    return advanced_sim
+
+def test_physics_module_exchange_resources_should_share_attributes(advanced_sim):
     """Tests that the exchange_resources method properly shares attributes with another physics_module"""
-    simple_sim.input_data["PhysicsModules"]["AdvancedModule"] = {}
-    simple_sim = Simulation(simple_sim.input_data)
-    simple_sim.read_modules_from_input()
-    assert simple_sim.physics_modules[0]._input_data["name"] == "ExampleModule"
-    assert simple_sim.physics_modules[1]._input_data["name"] == "AdvancedModule"
-    for m in simple_sim.physics_modules:
+    assert advanced_sim.physics_modules[0]._input_data["name"] == "ExampleModule"
+    assert advanced_sim.physics_modules[1]._input_data["name"] == "AdvancedModule"
+    for m in advanced_sim.physics_modules:
         m.exchange_resources()
     for i in range (1,4):
-        assert simple_sim.physics_modules[0].__dict__[f"AdvancedModule_attr{i}"] == \
-               simple_sim.physics_modules[1].__dict__[f"attr{i}"]
+        assert advanced_sim.physics_modules[0].__dict__[f"AdvancedModule_attr{i}"] == \
+               advanced_sim.physics_modules[1].__dict__[f"attr{i}"]
 
-def test_physics_module_initialize_should_change_attributes(simple_sim):
+def test_physics_module_initialize_should_change_attributes(advanced_sim):
     """Tests that the initialize function properly changes the attributes of a physics_module"""
-    del simple_sim.input_data["PhysicsModules"]["ExampleModule"]
-    simple_sim.input_data["PhysicsModules"]["AdvancedModule"] = {}
-    initialized_sim = Simulation(simple_sim.input_data)
-    non_initialized_sim = Simulation(simple_sim.input_data)
-    initialized_sim.read_modules_from_input()
+    non_initialized_sim = Simulation(advanced_sim.input_data)
     non_initialized_sim.read_modules_from_input()
-    for m in initialized_sim.physics_modules:
+    for m in advanced_sim.physics_modules:
         m.initialize()
+    assert advanced_sim.physics_modules[1]._input_data["name"] == "AdvancedModule"
     for i in range (1,4):
-        assert non_initialized_sim.physics_modules[0].__dict__[f"attr{i}"] + 3 == \
-               initialized_sim.physics_modules[0].__dict__[f"attr{i}"]
+        assert non_initialized_sim.physics_modules[1].__dict__[f"attr{i}"] + 3 == \
+               advanced_sim.physics_modules[1].__dict__[f"attr{i}"]
 
-def test_prepare_simulation_physics_modules(simple_sim):
+def test_prepare_simulation_physics_modules(advanced_sim):
     """Tests that prepare_simulation correctly shares resources and initializes the physics_modules"""
-    simple_sim_input = simple_sim.input_data
-    simple_sim_input["PhysicsModules"]["AdvancedModule"] = {}
-    first_sim = Simulation(simple_sim_input)
-    second_sim = Simulation(simple_sim_input)
-    assert id(first_sim) != id(second_sim)
-    first_sim.read_modules_from_input()
-    for m in first_sim.physics_modules:
+    prepared_sim = Simulation(advanced_sim.input_data)
+    assert id(advanced_sim) != id(prepared_sim)
+    for m in advanced_sim.physics_modules:
         m.exchange_resources()
-    for m in first_sim.physics_modules:
+    for m in advanced_sim.physics_modules:
         m.initialize()
-    second_sim.prepare_simulation()
-    assert id(first_sim.physics_modules) != id(second_sim.physics_modules)
-    assert str(first_sim.physics_modules) == str(second_sim.physics_modules)
+    prepared_sim.prepare_simulation()
+    assert id(advanced_sim.physics_modules) != id(prepared_sim.physics_modules)
+    assert str(advanced_sim.physics_modules) == str(prepared_sim.physics_modules)
 
 def test_gridless_simulation(tmp_path):
     """Test a gridless simulation"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,16 +91,17 @@ def test_read_grid_from_input_should_set_grid_attr_when_called(simple_sim):
 
 def test_prepare_simulation_physics_modules(simple_sim):
     """Tests that prepare_simulation correctly initializes the physics_modules"""
-    other_sim = simple_sim
-    simple_sim.prepare_simulation()
+    other_sim = Simulation(simple_sim.input_data)
+    assert id(simple_sim) != id(other_sim)
+    other_sim.read_modules_from_input()
     for i in other_sim.physics_modules:
         i.exchange_resources()
     for j in other_sim.physics_modules:
         j.initialize()
+    simple_sim.prepare_simulation()
     for k in range(len(simple_sim.physics_modules)):
-        assert simple_sim.physics_modules[k] == other_sim.physics_modules[k]
-
-
+        assert id(simple_sim.physics_modules[k]) != id(other_sim.physics_modules[k])
+        assert str(simple_sim.physics_modules[k]) == str(other_sim.physics_modules[k])
 
 def test_gridless_simulation(tmp_path):
     """Test a gridless simulation"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -96,13 +96,6 @@ class AdvancedModule(PhysicsModule):
         self.attr1 = 1.0
         self.attr2 = 2.0
         self.attr3 = 3.0
-    
-    def update(self):
-        pass
-    
-    def inspect_resource(self, resource: dict):
-        for attribute in resource:
-            self.__setattr__(attribute, resource[attribute])
 
 PhysicsModule.register("AdvancedModule", AdvancedModule)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -110,7 +110,7 @@ class AdvancedModule(PhysicsModule):
 PhysicsModule.register("AdvancedModule", AdvancedModule)
 
 @pytest.fixture(name = "advanced_sim")
-def adv_sin_fixt(simple_sim):
+def adv_sim_fixt(simple_sim):
     simple_sim.input_data["PhysicsModules"]["AdvancedModule"] = {}
     advanced_sim = Simulation(simple_sim.input_data)
     advanced_sim.read_modules_from_input()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,6 +89,19 @@ def test_read_grid_from_input_should_set_grid_attr_when_called(simple_sim):
     assert simple_sim.grid.r_min == 0
     assert simple_sim.grid.r_max == 1
 
+def test_prepare_simulation(simple_sim):
+    """Tests that the prepare_simulation method operates the same as if the physics modules 
+    exchange resources and are initialized seperately"""
+    other_sim = simple_sim
+    simple_sim.prepare_simulation()
+    for m in other_sim.physics_modules:
+        m.exchange_resources()
+    for m in other_sim.physics_modules:
+        m.initialize()
+    for i in range(len(simple_sim.physics_modules)):
+        assert simple_sim.physics_modules[i] == other_sim.physics_modules[i]
+
+
 
 def test_gridless_simulation(tmp_path):
     """Test a gridless simulation"""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -109,6 +109,9 @@ def test_prepare_simulation_physics_modules(simple_sim):
     first_sim.read_modules_from_input()
     for i in first_sim.physics_modules:
         i.exchange_resources()
+    for i in range (1,4):
+        assert first_sim.physics_modules[0].__dict__[f"AdvancedModule_attr{i}"] == \
+               first_sim.physics_modules[1].__dict__[f"attr{i}"]
     for j in first_sim.physics_modules:
         j.initialize()
     second_sim.prepare_simulation()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,7 +139,7 @@ def sim_fixt():
 def test_that_simulation_is_created(share_sim):
     assert share_sim.physics_modules == []
 
-def test_that_sim_is_prepared_correctly(share_sim):
+def test_that_shared_resource_is_available_in_initialize(share_sim):
     share_sim.prepare_simulation()
     assert len(share_sim.physics_modules) == 2
     assert len(share_sim.physics_modules[0].data) == 1

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -197,7 +197,6 @@ class Simulation:
         print("Initializing PhysicsModules...")
         for m in self.physics_modules:
             m.exchange_resources()
-        for m in self.physics_modules:
             m.initialize()
 
         print("Initializing Diagnostics...")

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -197,6 +197,7 @@ class Simulation:
         print("Initializing PhysicsModules...")
         for m in self.physics_modules:
             m.exchange_resources()
+        for m in self.physics_modules:
             m.initialize()
 
         print("Initializing Diagnostics...")


### PR DESCRIPTION
# Pull Request
## Description
Reduce complexity of `prepare_simulation` method and write test that confirms the result is equivalent to running `exchange_resources` and `initialize` separately.

This pull request addresses # \
Fixes #

## Checklist
The following items have been checked for this PR:

- [x] Conforms to PEP8 style standards (check with `pylint`, `flake8`, or similar)
- [x] Code is documented with docstrings, or docstrings have been updated as appropriate
- [x] New unit test/integration test have been added to check new code
- [x] All existing tests still pass
