### PR TITLE
Refactor for less complexity

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -275,6 +275,12 @@ def test_create_interpolator(simple_grid):
     interp = simple_grid.create_interpolator(r_val)
     linear_value = r_val / (simple_grid.r_max - simple_grid.r_min)
     assert np.allclose(interp(field), linear_value)
+    r_val = -0.1
+    with pytest.raises(AssertionError):
+        interp = simple_grid.create_interpolator(r_val)
+    r_val = 0.2
+    with pytest.raises(AssertionError):
+        interp = simple_grid.create_interpolator(r_val)
 
 
 def test_set_cartesian_volumes():

--- a/turbopy/core.py
+++ b/turbopy/core.py
@@ -264,7 +264,7 @@ class Simulation:
 
             for diag_type, d in diags.items():
                 diagnostic_class = Diagnostic.lookup(diag_type)
-                if not type(d) is list:
+                if type(d) is not list:
                     d = [d]
                 file_num = 0
                 for di in d:
@@ -807,7 +807,7 @@ class Grid:
                                     "in the grid")
         if len(i) == 1:
             return lambda y: y[i]
-        if len(i) == 2:
+        else:
             # linearly interpolate
             def interpval(yvec):
                 """A function which takes a grid quantity ``y`` and


### PR DESCRIPTION
# Pull Request
## Description
Reduces cyclomatic complexity of `Grid.create_interpolator` and adds assert statements to `test/test_core.py` that checks the point is in the field. 

This pull request addresses NRL-Plasma-Physics-Division/turbopy-bootcamp#113
Fixes #

## Checklist
The following items have been checked for this PR:

- [x] Conforms to PEP8 style standards (check with `pylint`, `flake8`, or similar)
- [x] Code is documented with docstrings, or docstrings have been updated as appropriate
- [x] New unit test/integration test have been added to check new code
- [x] All existing tests still pass
